### PR TITLE
adding missing escaping for a working treafik deployment

### DIFF
--- a/scripts/prepare-docker-compose.sh
+++ b/scripts/prepare-docker-compose.sh
@@ -50,7 +50,7 @@ services:
       - "traefik.enable=true"
       - "traefik.docker.network=traefik_default"
       - "traefik.http.services.\${TRAEFIK_LABEL}.loadbalancer.server.port=8080"
-      - "traefik.http.routers.\${TRAEFIK_LABEL}.rule=Host(`\${DOMAIN}`)"
+      - "traefik.http.routers.\${TRAEFIK_LABEL}.rule=Host(\`\${DOMAIN}\`)"
       - "traefik.http.routers.\${TRAEFIK_LABEL}.entrypoints=websecure"
       - "traefik.http.routers.\${TRAEFIK_LABEL}.tls=true"
       - "traefik.http.routers.\${TRAEFIK_LABEL}.tls.certresolver=leresolver"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the syntax in the Docker Compose configuration for Traefik to ensure proper processing of the `${DOMAIN}` variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->