### PR TITLE
Adding traefik rule to redirect all traffic from http to https

### DIFF
--- a/scripts/prepare-docker-compose.sh
+++ b/scripts/prepare-docker-compose.sh
@@ -49,6 +49,10 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=traefik_default"
+      - "traefik.http.routers.services.\${TRAEFIK_LABEL}-http.entrypoints=web"
+      - "traefik.http.routers.services.\${TRAEFIK_LABEL}-http.rule=Host(\`\${DOMAIN}\`)"
+      - "traefik.http.routers.services.\${TRAEFIK_LABEL}-http.middlewares=services.\${TRAEFIK_LABEL}-https"
+      - "traefik.http.middlewares.services.\${TRAEFIK_LABEL}-https.redirectscheme.scheme=https"
       - "traefik.http.services.\${TRAEFIK_LABEL}.loadbalancer.server.port=8080"
       - "traefik.http.routers.\${TRAEFIK_LABEL}.rule=Host(\`\${DOMAIN}\`)"
       - "traefik.http.routers.\${TRAEFIK_LABEL}.entrypoints=websecure"


### PR DESCRIPTION
Per default, the traefik setup does not redirect call that came via http://.... 
This rule, routes all http://....  requests to https://.... 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced frontend service integration with Traefik for improved routing and HTTPS redirection.
	- Added new routing and middleware labels to streamline service access.

- **Bug Fixes**
	- Retained existing Traefik configurations to ensure continued functionality with load balancer and TLS settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->